### PR TITLE
count non missing

### DIFF
--- a/R/assocTestAggregate.R
+++ b/R/assocTestAggregate.R
@@ -63,7 +63,8 @@ setMethod("assocTestAggregate",
                   }
 
                   # number of non-missing samples
-                  n.obs <- colSums(!is.na(geno))
+                  # n.obs <- colSums(!is.na(geno))
+                  n.obs <- .countNonMissing(geno, MARGIN = 2)
                   
                   # allele frequency
                   freq <- .alleleFreq(gdsobj, geno, variant.index=index, sample.index=sample.index,
@@ -175,7 +176,8 @@ setMethod("assocTestAggregate",
                                                transpose=TRUE, use.names=FALSE, drop=FALSE)
                   
                   # number of non-missing samples
-                  n.obs <- colSums(!is.na(geno))
+                  # n.obs <- colSums(!is.na(geno))
+                  n.obs <- .countNonMissing(geno, MARGIN = 2)
                   
                   # allele frequency
                   freq <- .alleleFreq(gdsobj, geno, sample.index=sample.index,

--- a/R/assocTestSingle.R
+++ b/R/assocTestSingle.R
@@ -36,7 +36,8 @@ setMethod("assocTestSingle",
                   }
                   
                   # take note of number of non-missing samples
-                  n.obs <- colSums(!is.na(geno))
+                  #n.obs <- colSums(!is.na(geno))
+                  n.obs <- .countNonMissing(geno, MARGIN = 2)
                   
                   # allele frequency
                   freq <- .alleleFreq(gdsobj, geno, sample.index=sample.index,
@@ -96,7 +97,8 @@ setMethod("assocTestSingle",
                                                transpose=TRUE, use.names=FALSE, drop=FALSE)
                   
                   # take note of number of non-missing samples
-                  n.obs <- colSums(!is.na(geno))
+                  #n.obs <- colSums(!is.na(geno))
+                  n.obs <- .countNonMissing(geno, MARGIN = 2)
                   
                   # allele frequency
                   freq <- .alleleFreq(gdsobj, geno, sample.index=sample.index,

--- a/R/util_methods.R
+++ b/R/util_methods.R
@@ -85,7 +85,7 @@ setMethod(".countNonMissing",
                 colSums(!is.na(x))
               }
             }else{
-              GENESIS:::.apply(geno, 
+              .apply(geno, 
                     MARGIN = MARGIN, 
                     FUN = function(x){ sum(!is.na(x)) },
                     selection = list(1:nr, 1:nc))

--- a/R/util_methods.R
+++ b/R/util_methods.R
@@ -60,6 +60,38 @@ setMethod(".apply",
           })
 
 
+setGeneric(".countNonMissing", function(x, MARGIN) standardGeneric(".countNonMissing"))
+
+setMethod(".countNonMissing",
+          "matrix",
+          function(x, MARGIN){
+            if(MARGIN == 1){
+              rowSums(!is.na(x))
+            }else if(MARGIN == 2){
+              colSums(!is.na(x))
+            }
+          })
+
+setMethod(".countNonMissing",
+          "Matrix",
+          function(x, MARGIN){
+            nr <- as.numeric(nrow(x))
+            nc <- as.numeric(ncol(x))
+
+            if(nr*nc < 2^31){
+              if(MARGIN == 1){
+                rowSums(!is.na(x))
+              }else if(MARGIN == 2){
+                colSums(!is.na(x))
+              }
+            }else{
+              GENESIS:::.apply(geno, 
+                    MARGIN = MARGIN, 
+                    FUN = function(x){ sum(!is.na(x)) },
+                    selection = list(1:nr, 1:nc))
+            }
+            })
+
 
 setGeneric(".readSampleId", function(x) standardGeneric(".readSampleId"))
 setMethod(".readSampleId",

--- a/R/utils.R
+++ b/R/utils.R
@@ -68,7 +68,8 @@ setMethod("variantFilter",
     if (is.null(sex)) {
         #freq <- 0.5*colMeans(geno, na.rm=TRUE)
         count <- colSums(geno, na.rm=TRUE)
-        nsamp <- colSums(!is.na(geno))
+        # nsamp <- colSums(!is.na(geno))
+        nsamp <- .countNonMissing(geno, MARGIN = 2)
         freq <- count/(2*nsamp)
         mac <- round(pmin(count, 2*nsamp - count))
         return(data.frame(freq=freq, MAC=mac))
@@ -90,7 +91,8 @@ setMethod("variantFilter",
     if (any(auto)) {
         #freq[auto] <- 0.5*colMeans(geno[, auto, drop=FALSE], na.rm=TRUE)
         count[auto] <- colSums(geno[, auto, drop=FALSE], na.rm=TRUE)
-        possible[auto] <- 2 * colSums(!is.na(geno[, auto, drop=FALSE]))
+        # possible[auto] <- 2 * colSums(!is.na(geno[, auto, drop=FALSE]))
+        possible[auto] <- 2 * .countNonMissing(geno[, auto, drop=FALSE], MARGIN = 2)
     }
 
     # X chrom
@@ -98,12 +100,14 @@ setMethod("variantFilter",
         female <- sex %in% "F"
         male <- sex %in% "M"
         F.count <- colSums(geno[female, X, drop=FALSE], na.rm=TRUE)
-        F.nsamp <- colSums(!is.na(geno[female, X, drop=FALSE]))
+        # F.nsamp <- colSums(!is.na(geno[female, X, drop=FALSE]))
+        F.nsamp <- .countNonMissing(geno[female, X, drop=FALSE], MARGIN = 2)
         M.count <- colSums(geno[male, X, drop=FALSE], na.rm=TRUE)
         if (male.diploid) {
             M.count <- 0.5*M.count
         }
-        M.nsamp <- colSums(!is.na(geno[male, X, drop=FALSE]))
+        # M.nsamp <- colSums(!is.na(geno[male, X, drop=FALSE]))
+        M.nsamp <- .countNonMissing(geno[male, X, drop=FALSE], MARGIN = 2)
         #freq[X] <- (F.count + M.count)/(2*F.nsamp + M.nsamp)
         count[X] <- (F.count + M.count)
         possible[X] <- (2*F.nsamp + M.nsamp)
@@ -118,7 +122,8 @@ setMethod("variantFilter",
             #freq[Y] <- 0.5*freq[Y]
             count[Y] <- 0.5*count[Y]
         }
-        possible[Y] <- colSums(!is.na(geno[male, Y, drop=FALSE]))
+        # possible[Y] <- colSums(!is.na(geno[male, Y, drop=FALSE]))
+        possible[Y] <- .countNonMissing(geno[male, Y, drop=FALSE], MARGIN = 2)
     }
 
     freq <- count / possible


### PR DESCRIPTION
is.na can not be applied to Matrix objects with > 2^31 elements. This breaks our code for counting the number of observed genotypes in a few places. 

Added a .countNonMissing function to utils.
Updated assocTestAggregate and .alleleFreq to use this function.