### PR TITLE
Add a helper function to calculate and filter pchisq values

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -352,3 +352,10 @@ setMethod(".annotateAssoc",
     put.attr.gdsn(geno.node, "sample.order")
     closefn.gds(gds)
 }
+
+.pchisq_filter_extreme <- function(...) {
+    # Note: stat is the squared test statistic.
+    pval = pchisq(...)
+    pval[pval < .Machine$double.xmin] = .Machine$double.xmin
+    return(pval)
+}


### PR DESCRIPTION
Filter p-values based on the Machine$double.xmin value: if a p-value calculated with pchisq is smaller than Machine$double.xmin, then set it to the double.xmin value.

This should prevent pval=0 situations.

Closes #110 