### PR TITLE
Enable imputed dosage for admixmap()

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
 ^renv$
 ^renv\.lock$
 ^\.github$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/R/admixMap.R
+++ b/R/admixMap.R
@@ -81,7 +81,9 @@ admixMap <- function(admixDataList,
             if (is(admixDataList[[1]], "GenotypeIterator")) {
                 local[,,i] <- getGenotypeSelection(admixDataList[[i]], scan=sample.index, order="selection", transpose=TRUE, use.names=FALSE, drop=FALSE)
             } else {
-                local[,,i] <- refDosage(admixDataList[[i]], use.names=FALSE)[sample.index,,drop=FALSE]
+               # local[,,i] <- refDosage(admixDataList[[i]], use.names=FALSE)[sample.index,,drop=FALSE]
+               local[,,i] <- imputedDosage(admixDataList[[i]], use.names=FALSE)[sample.index,,drop=FALSE]
+              
             }
         }
         if (any(is.na(local))) warning("missing values in local ancestry will produce NA output for this block")

--- a/R/admixMap.R
+++ b/R/admixMap.R
@@ -1,6 +1,7 @@
 admixMap <- function(admixDataList,
                      null.model,
-                     male.diploid=TRUE, genome.build=c("hg19", "hg38"),
+                     male.diploid=TRUE, genome.build=c("hg19", "hg38"),imputed=FALSE,
+                     dosage.field="DS",
                      BPPARAM=bpparam(), verbose=TRUE){
 
     # if admixDataList is one file, convert to a list
@@ -15,7 +16,7 @@ admixMap <- function(admixDataList,
     if(is.null(names(admixDataList))){
         names(admixDataList) <- paste("Anc",1:v,sep="")
     }
-
+   
     # get sample index
     if (is(admixDataList[[1]], "GenotypeIterator")) {
         sample.index <- lapply(admixDataList, .sampleIndexNullModel, null.model)
@@ -29,6 +30,10 @@ admixMap <- function(admixDataList,
         stop("admixDataList must contain GenotypeIterator or SeqVarIterator objects")
     }
     n.samp <- length(sample.index)
+    
+    # if admixDataList contain GenotypeIterator, imputed=TRUE will be ignored
+    if (is(admixDataList[[1]], "GenotypeIterator") && imputed=TRUE)
+        print("admixDataList contain GenotypeIterator, imputed=TRUE is ignored")
     
     # get sex for calculating allele freq
     sex <- validateSex(admixDataList[[1]])[sample.index]
@@ -81,8 +86,10 @@ admixMap <- function(admixDataList,
             if (is(admixDataList[[1]], "GenotypeIterator")) {
                 local[,,i] <- getGenotypeSelection(admixDataList[[i]], scan=sample.index, order="selection", transpose=TRUE, use.names=FALSE, drop=FALSE)
             } else {
-               # local[,,i] <- refDosage(admixDataList[[i]], use.names=FALSE)[sample.index,,drop=FALSE]
-               local[,,i] <- imputedDosage(admixDataList[[i]], use.names=FALSE)[sample.index,,drop=FALSE]
+               if(imputed=FALSE){
+                local[,,i] <- refDosage(admixDataList[[i]], use.names=FALSE)[sample.index,,drop=FALSE]
+               }else
+                local[,,i] <- imputedDosage(admixDataList[[i]], use.names=FALSE,dosage.field="DS")[sample.index,,drop=FALSE]
               
             }
         }

--- a/man/admixMap.Rd
+++ b/man/admixMap.Rd
@@ -7,7 +7,8 @@ Run admixture analyses
 }
 \usage{
 admixMap(admixDataList, null.model, male.diploid=TRUE,
-         genome.build=c("hg19", "hg38"),
+         genome.build=c("hg19", "hg38"),imputed=FALSE,
+         dosage.field="DS",
          BPPARAM=bpparam(), verbose=TRUE)
 }
 
@@ -16,6 +17,8 @@ admixMap(admixDataList, null.model, male.diploid=TRUE,
     \item{null.model}{A null model object returned by \code{\link{fitNullModel}}.}
     \item{male.diploid}{Logical for whether males on sex chromosomes are coded as diploid. Default is `male.diploid=TRUE`, meaning sex chromosome genotypes for males have values 0/2. If the input object codes males as 0/1 on sex chromosomes, set `male.diploid=FALSE`.}
   \item{genome.build}{A character sting indicating genome build; used to identify pseudoautosomal regions on the X and Y chromosomes. These regions are not treated as sex chromosomes when calculating allele frequencies.}
+   \item{imputed}{Logical indicator of whether to read dosages from the field specified in `dosage.field`,containing imputed dosages instead of counting the number of ref alleles. Only relevant when admixDataList contains \code{\link{SeqVarIterator}}, i.e. ignored when admixDataList contains \code{\link{GenotypeIterator}}  }
+   \item{dosage.field}{The name of the dosage field in the GDS object (will be prepended with "annotation/format"). Default is dosage.field='DS'.}
   \item{BPPARAM}{A \code{\link{BiocParallelParam}} object to process blocks of variants in parallel. If not provided, the default back-end returned by \code{\link{bpparam}} will be used.}
     \item{verbose}{Logical indicator of whether updates from the function should be printed to the console; the default is TRUE.}
 }


### PR DESCRIPTION
I have added imputed and dosage.field options for admixmap() to allow users to use the imputed dosage in GDS object in "annotation/format", where the dosage field name is specified in dosage.field (default is 'DS' ).