### PR TITLE
Fix build

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: GENetic EStimation and Inference in Structured samples
         (GENESIS): Statistical methods for analyzing genetic data from
         samples with population structure and/or relatedness
-Version: 2.38.0
+Version: 2.39.0
 Date: 2025-01-31
 Author: Matthew P. Conomos, Stephanie M. Gogarten,
 	Lisa Brown, Han Chen, Thomas Lumley, Kenneth Rice, Tamar Sofer, Adrienne Stilp, Timothy Thornton, Chaoyu Yu

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: GENetic EStimation and Inference in Structured samples
         (GENESIS): Statistical methods for analyzing genetic data from
         samples with population structure and/or relatedness
-Version: 2.37.1
+Version: 2.38.0
 Date: 2025-01-31
 Author: Matthew P. Conomos, Stephanie M. Gogarten,
 	Lisa Brown, Han Chen, Thomas Lumley, Kenneth Rice, Tamar Sofer, Adrienne Stilp, Timothy Thornton, Chaoyu Yu

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: GENetic EStimation and Inference in Structured samples
         (GENESIS): Statistical methods for analyzing genetic data from
         samples with population structure and/or relatedness
-Version: 2.39.0
+Version: 2.39.1
 Date: 2025-01-31
 Author: Matthew P. Conomos, Stephanie M. Gogarten,
 	Lisa Brown, Han Chen, Thomas Lumley, Kenneth Rice, Tamar Sofer, Adrienne Stilp, Timothy Thornton, Chaoyu Yu

--- a/vignettes/assoc_test_seq.Rmd
+++ b/vignettes/assoc_test_seq.Rmd
@@ -226,6 +226,7 @@ In this example, we illustrate defining ranges based on known genes. We run a bu
 
 ```{r}
 library(GenomicRanges)
+library(GenomeInfoDb)
 library(TxDb.Hsapiens.UCSC.hg19.knownGene)
 
 # return the variants on chromosome 1 as a GRanges object


### PR DESCRIPTION
Build is failing because the function renameSeqlevels used in the assoc_test_seq vignette is undefined. Load the GenomeInfoDb package, which now contains this function.