### PR TITLE
selectRandomVariants can't have infinite loop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: GENetic EStimation and Inference in Structured samples
         (GENESIS): Statistical methods for analyzing genetic data from
         samples with population structure and/or relatedness
-Version: 2.39.2
+Version: 2.39.3
 Date: 2025-01-31
 Author: Matthew P. Conomos, Stephanie M. Gogarten,
 	Lisa Brown, Han Chen, Thomas Lumley, Kenneth Rice, Tamar Sofer, Adrienne Stilp, Timothy Thornton, Chaoyu Yu
@@ -37,3 +37,4 @@ biocViews: SNP, GeneticVariability, Genetics, StatisticalMethod,
         DimensionReduction, PrincipalComponent, GenomeWideAssociation,
         QualityControl, BiocViews
 NeedsCompilation: no
+RoxygenNote: 7.3.3

--- a/R/nullModelFastScore.R
+++ b/R/nullModelFastScore.R
@@ -131,6 +131,7 @@ setMethod(".selectRandomVars",
                    sample.id = NULL, 
                    nvar = 100, 
                    min.mac = 20, 
+                   max.iter = 100,
                    verbose = TRUE){
 
             # filter to sample set in null.model
@@ -145,6 +146,7 @@ setMethod(".selectRandomVars",
             if(nvar.gds < nvar) stop('requested more variants than available in gdsobj')
 
             out <- NULL
+            niter <- 0
             while(length(out) < nvar){
               # sample variants
               var.rand <- sort(sample(var.filt, size = nvar, replace = FALSE))
@@ -154,6 +156,8 @@ setMethod(".selectRandomVars",
               if(min.mac > 0) SeqArray::seqSetFilterCond(gdsobj, mac = min.mac, verbose = verbose)
               # collect selected variants
               out <- sort(unique(c(out, seqGetData(gdsobj, 'variant.id'))))
+              niter <- niter + 1
+              if (niter > max.iter) stop("exceeded maximum number of iterations to select variants")
             }
 
             # sample down to number requested

--- a/man/assocTestSingle.Rd
+++ b/man/assocTestSingle.Rd
@@ -165,8 +165,9 @@ assoc <- assocTestSingle(iterator, nullmod,
 seqResetFilter(seqData)
 grm <- SNPRelate::snpgdsGRM(seqData, verbose=FALSE)
 covmat <- grm$grm; dimnames(covmat) <- list(grm$sample.id, grm$sample.id)
-set.seed(5)
-nullmod <- fitNullModelFastScore(iterator, outcome="outcome", covars="sex", cov.mat=covmat)
+set.seed(10)
+nullmod <- fitNullModelFastScore(iterator, outcome="outcome", covars="sex", cov.mat=covmat,
+                                 nvar=50, min.mac=2)
 assoc.se <- assocTestSingle(iterator, nullmod, fast.score.SE=TRUE,
                             BPPARAM=BiocParallel::SerialParam())
 

--- a/tests/testthat/test_fastScoreSE.R
+++ b/tests/testthat/test_fastScoreSE.R
@@ -9,14 +9,15 @@ test_that("fast score SE", {
     
     nm <- fitNullModel(svd, outcome="outcome", covars=c("sex", "age"), cov.mat=covmat, verbose=FALSE)
     set.seed(123)
-    nm.se <- fitNullModelFastScore(svd, outcome="outcome", covars=c("sex", "age"), cov.mat=covmat, verbose=FALSE)
+    nm.se <- fitNullModelFastScore(svd, outcome="outcome", covars=c("sex", "age"), cov.mat=covmat,
+                                   nvar=50, min.mac=2, verbose=FALSE)
     expect_true(all(c("se.correction", "score.table") %in% names(nm.se)))
     
     chk <- intersect(names(nm), names(nm.se))
     expect_equal(nm[chk], nm.se[chk])
     
     set.seed(456)
-    score.table <- calcScore(svd, nm, verbose=FALSE)
+    score.table <- calcScore(svd, nm, nvar=50, min.mac=2, verbose=FALSE)
     nm2 <- nullModelFastScore(nm, score.table, verbose=FALSE)
     expect_equal(nm2, nm.se)
     
@@ -28,7 +29,7 @@ test_that("fast score SE", {
     resetIterator(iterator, verbose=FALSE)
     set.seed(789)
     assoc.se <- assocTestSingle(iterator, nm.se, fast.score.SE=TRUE, BPPARAM=BPPARAM, verbose=FALSE)
-    expect_equal(assoc, assoc.se, tolerance=0.0001)
+    expect_equal(assoc, assoc.se, tolerance=0.002)
     
     seqClose(svd)
 })

--- a/tests/testthat/test_nullModel.R
+++ b/tests/testthat/test_nullModel.R
@@ -300,7 +300,7 @@ test_that("missing data - data.frame", {
     dat <- data.frame(a=a,
                       b=c(rep(NA, 5), rep("a",5), rep("b", 5)),
                       stringsAsFactors=FALSE)
-    set.seed(35); covMat <- crossprod(matrix(rnorm(15*2,sd=0.05),15,15))
+    set.seed(35); covMat <- crossprod(matrix(rnorm(15*15,sd=0.05),15,15))
     nm <- fitNullModel(dat, outcome="a", covars="b", cov.mat=covMat, group="b", verbose=FALSE)
     expect_equivalent(rownames(nm$model.matrix), as.character(6:15))
     expect_equivalent(nm$fit$workingY, dat$a[6:15])
@@ -313,7 +313,7 @@ test_that("missing data - AnnotatedDataFrame", {
                       b=c(rep(NA, 5), rep("a",5), rep("b", 5)),
                       stringsAsFactors=FALSE)
     dat <- AnnotatedDataFrame(dat)
-    set.seed(37); covMat <- crossprod(matrix(rnorm(15*2,sd=0.05),15,15))
+    set.seed(37); covMat <- crossprod(matrix(rnorm(15*15,sd=0.05),15,15))
     dimnames(covMat) <- list(dat$sample.id, dat$sample.id)
     nm <- fitNullModel(dat, outcome="a", covars="b", cov.mat=covMat, group="b", verbose=FALSE)
     expect_equal(nm$fit$sample.id, dat$sample.id[6:15])
@@ -346,8 +346,8 @@ test_that("multiple matrices", {
                       b=c(rep("a",5), rep("b", 5)),
                       stringsAsFactors=FALSE)
     dat <- AnnotatedDataFrame(dat)
-    set.seed(41); covMat <- crossprod(matrix(rnorm(15*2,sd=0.05),10,10, dimnames=list(samp,samp)))
-    set.seed(42); covMat2 <- crossprod(matrix(rnorm(15*2,sd=0.05),10,10, dimnames=list(samp,samp)))
+    set.seed(41); covMat <- crossprod(matrix(rnorm(100,sd=0.05),10,10, dimnames=list(samp,samp)))
+    set.seed(42); covMat2 <- crossprod(matrix(rnorm(100,sd=0.05),10,10, dimnames=list(samp,samp)))
     covMatList <- list(covMat, covMat2)
     nm1 <- fitNullModel(dat, outcome="a", covars="b", cov.mat=covMatList, verbose=FALSE)
     nm <- fitNullModel(dat, outcome="a", covars="b", cov.mat=covMatList, verbose=FALSE)


### PR DESCRIPTION
the example code was failing for fitNUllModelFastScore due to an infinite loop. set a maximum number of iterations in the code before it stops with an error message. Also change inputs to the example code so it runs without error.